### PR TITLE
Use HTML 5 apostrophe entity

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,7 @@ export default function Home() {
           </h1>
           <p className="mt-6 text-gray-600 dark:text-white dark:text-opacity-75">
             As a self-taught web developer, I focus on building modern applications using React,
-            Next.js, and Docker. I'm continuously learning and applying new skills through my
+            Next.js, and Docker. I&apos;m continuously learning and applying new skills through my
             personal projects, focusing on performance, scalability, and user experience.
           </p>
         </header>


### PR DESCRIPTION
## Description
Replaced the apostrophe via the home page with the HTML 5 entity `&apos;`.

## Changes
- [x] Replaced the apostrophe

## Checklist
- [x] Tested locally

## Related Issues
This fixes issue #6.